### PR TITLE
Clones Mock Staked SUI object from System Contract

### DIFF
--- a/packages/move/tests/staked_sui_tests.move
+++ b/packages/move/tests/staked_sui_tests.move
@@ -1,26 +1,35 @@
 #[test_only]
 module legato::staked_sui_tests {
 
-    use legato::staked_sui::{Self, STAKED_SUI};
-    use sui::coin::{TreasuryCap};
-    use sui::test_scenario::{Self, next_tx, ctx};
+    use sui::coin::{Self};
+    use sui::sui::SUI;
+    use legato::staked_sui::{Self, StakedSui};
+    use sui::test_scenario::{Self as test, next_tx, Scenario, ctx};
 
     #[test]
-    fun mint() {
-        let addr1 = @0xA;
-
-        let scenario = test_scenario::begin(addr1);
-        {
-            staked_sui::test_init(ctx(&mut scenario))
-        };
-         
-        next_tx(&mut scenario, addr1);
-        {
-            let treasurycap = test_scenario::take_shared<TreasuryCap<STAKED_SUI>>(&scenario);
-            staked_sui::mint(&mut treasurycap, 100, test_scenario::ctx(&mut scenario));
-            test_scenario::return_shared<TreasuryCap<STAKED_SUI>>(treasurycap);
-        };
-
-        test_scenario::end(scenario);
+    public fun test_wrap_unwrap() {
+        let scenario = scenario();
+        test_wrap_unwrap_(&mut scenario);
+        test::end(scenario);
     }
+
+    #[test_only]
+    fun test_wrap_unwrap_(test: &mut Scenario) {
+        let addr1 = @0xA;
+        
+        next_tx(test, addr1);
+        {
+            let sui_token = coin::mint_for_testing<SUI>(100, ctx(test));
+            staked_sui::wrap(sui_token, ctx(test));
+        };
+
+        next_tx(test, addr1);
+        {
+            let staked_sui = test::take_from_sender<StakedSui>(test);
+            staked_sui::unwrap(staked_sui, ctx(test));
+        };
+
+    }   
+
+    fun scenario(): Scenario { test::begin(@0x1) }
 }


### PR DESCRIPTION
Previously, we used the mock staked SUI based on the Coin object. We would rather update it to have the same struct / functionality as the actual system contract has.

And after this PR is merged, we can update the vault to be able to use the staked SUI object received from the validator node.