### PR TITLE
Deposit Cap

### DIFF
--- a/packages/move/tests/marketplace_tests.move
+++ b/packages/move/tests/marketplace_tests.move
@@ -171,6 +171,8 @@ module legato::marketplace_tests {
             let global = test::take_shared<Marketplace>(test);
             let managercap = test::take_from_sender<ManagerCap>(test);
             marketplace::setup_quote<USDC>(&mut global, &mut managercap,  ctx(test));
+            // marketplace::set_deposit_cap(&mut global, &mut managercap,  1_000_000_000);
+            // marketplace::set_deposit_cap(&mut global, &mut managercap,  0);
             test::return_shared(global);
             test::return_to_sender(test, managercap);
         };

--- a/packages/move/tests/vault_basic_tests.move
+++ b/packages/move/tests/vault_basic_tests.move
@@ -84,6 +84,8 @@ module legato::vault_basic_tests {
 
             vault::update_vault_apy<JAN_2024>(&mut global, &mut managercap , median_apy);
 
+            // vault::set_deposit_cap(&mut global, &mut managercap, 100_000_000_000);
+
             test::return_shared(global);
             test::return_shared(system_state);
             test::return_to_sender(test, managercap);


### PR DESCRIPTION
We implemented a deposit cap to prevent users from staking or depositing more than the value we set until before passing the security audit. The tentative cap will be equivalent to $50,000 to $100,000.